### PR TITLE
[PROD] Increase fargate ephemeral storage to 100 GB.

### DIFF
--- a/copilot/export-worker/manifest.yml
+++ b/copilot/export-worker/manifest.yml
@@ -69,6 +69,8 @@ environments:
   prod:
     cpu: 2048
     memory: 16384
+    storage:
+      ephemeral: 100
 
     logging:
       retention: 180


### PR DESCRIPTION
20 GB of ephemeral storage is available for all Fargate Tasks and Pods by
default—we only pay for any additional storage that you configure.
Pricing: https://aws.amazon.com/fargate/pricing/