### PR TITLE
Update gh deprecated set-output

### DIFF
--- a/.github/workflows/ary-deploy.yml
+++ b/.github/workflows/ary-deploy.yml
@@ -27,11 +27,11 @@ jobs:
           DEEP_CLIENT_BRANCH=`jq -r '.ary_client.branch' ${SUB_MODULES_DEP_FILE}`
           DEEP_REACT_STORE_REPO=`jq -r '.ary_client.react_store_repo' ${SUB_MODULES_DEP_FILE}`
           DEEP_REACT_STORE_BRANCH=`jq -r '.ary_client.react_store_branch' ${SUB_MODULES_DEP_FILE}`
-          echo ::set-output name=deploy::${DEEP_CLIENT_DEPLOY}
-          echo ::set-output name=branch::${DEEP_CLIENT_BRANCH}
-          echo ::set-output name=repo::${DEEP_CLIENT_REPO#https://github.com/}
-          echo ::set-output name=react_store_repo::${DEEP_REACT_STORE_REPO#https://github.com/}
-          echo ::set-output name=react_store_branch::${DEEP_REACT_STORE_BRANCH}
+          echo "deploy=${DEEP_CLIENT_DEPLOY}" >> $GITHUB_OUTPUT
+          echo "branch=${DEEP_CLIENT_BRANCH}" >> $GITHUB_OUTPUT
+          echo "repo=${DEEP_CLIENT_REPO#https://github.com/}" >> $GITHUB_OUTPUT
+          echo "react_store_repo=${DEEP_REACT_STORE_REPO#https://github.com/}" >> $GITHUB_OUTPUT
+          echo "react_store_branch=${DEEP_REACT_STORE_BRANCH}" >> $GITHUB_OUTPUT
 
   test_build:
     name: Lint + Test + Build
@@ -58,8 +58,8 @@ jobs:
         run: |
           TAG=$(echo $GITHUB_SHA | head -c7)
           IMAGE="docker.pkg.github.com/the-deep/client"
-          echo ::set-output name=tagged_image::${IMAGE}:${TAG}
-          echo ::set-output name=tag::${TAG}
+          echo "tagged_image=${IMAGE}:${TAG}" >> $GITHUB_OUTPUT
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
       - name: 🐳 Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@master

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,9 +23,9 @@ jobs:
           DEEP_CLIENT_DEPLOY=`jq -r '.client.deploy' ${SUB_MODULES_DEP_FILE}`
           DEEP_CLIENT_REPO=`jq -r '.client.repo' ${SUB_MODULES_DEP_FILE}`
           DEEP_CLIENT_BRANCH=`jq -r '.client.branch' ${SUB_MODULES_DEP_FILE}`
-          echo ::set-output name=deploy::${DEEP_CLIENT_DEPLOY}
-          echo ::set-output name=branch::${DEEP_CLIENT_BRANCH}
-          echo ::set-output name=repo::${DEEP_CLIENT_REPO#https://github.com/}
+          echo "deploy=${DEEP_CLIENT_DEPLOY}" >> $GITHUB_OUTPUT
+          echo "branch=${DEEP_CLIENT_BRANCH}" >> $GITHUB_OUTPUT
+          echo "repo=${DEEP_CLIENT_REPO#https://github.com/}" >> $GITHUB_OUTPUT
 
   test_build:
     name: Lint + Test + Build
@@ -45,8 +45,8 @@ jobs:
         run: |
           TAG=$(echo $GITHUB_SHA | head -c7)
           IMAGE="docker.pkg.github.com/the-deep/client"
-          echo ::set-output name=tagged_image::${IMAGE}:${TAG}
-          echo ::set-output name=tag::${TAG}
+          echo "tagged_image=${IMAGE}:${TAG}" >> $GITHUB_OUTPUT
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
       - name: 🐳 Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@master

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,7 @@ services:
       POSTGRES_DB: deep
     volumes:
       - postgres-data13:/var/lib/postgresql/data
+    # command: postgres -c log_statement=all
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
       interval: 10s


### PR DESCRIPTION
Related: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/